### PR TITLE
feat: add PollIntervalSeconds to ConfigResponse

### DIFF
--- a/types.go
+++ b/types.go
@@ -81,6 +81,12 @@ type ConfigResponse struct {
 	SmartRouting      SmartRoutingRules `json:"smart_routing,omitempty"`
 	AdBlock           AdBlockRules      `json:"ad_block,omitempty"`
 
+	// PollIntervalSeconds tells the client how long to wait before fetching
+	// a new config. The server adjusts this based on bandit confidence —
+	// shorter intervals when learning (new ASN, high entropy), longer when
+	// the assignment is stable. Zero means use the client's default.
+	PollIntervalSeconds int `json:"poll_interval_seconds,omitempty"`
+
 	// BanditURLOverrides maps outbound tags to per-proxy callback URLs for
 	// the bandit Thompson sampling system. When set, these override the
 	// default MutableURLTest URL for each specific outbound, allowing the

--- a/types_test.go
+++ b/types_test.go
@@ -102,6 +102,29 @@ func TestConfigResponseSerialization(t *testing.T) {
 	}
 }
 
+func TestPollIntervalSecondsRoundTrip(t *testing.T) {
+	original := ConfigResponse{
+		PollIntervalSeconds: 30,
+	}
+
+	data, err := json.Marshal(original)
+	assert.NoError(t, err)
+
+	// Non-zero value should appear in JSON
+	assert.Contains(t, string(data), `"poll_interval_seconds":30`)
+
+	var deserialized ConfigResponse
+	err = json.Unmarshal(data, &deserialized)
+	assert.NoError(t, err)
+	assert.Equal(t, 30, deserialized.PollIntervalSeconds)
+
+	// Zero value should be omitted from JSON
+	zeroResp := ConfigResponse{}
+	data, err = json.Marshal(zeroResp)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(data), "poll_interval_seconds")
+}
+
 func TestConfigResponseDefaultValues(t *testing.T) {
 	resp := ConfigResponse{}
 	if len(resp.Servers) != 0 {


### PR DESCRIPTION
## Summary
Add `PollIntervalSeconds` field to `ConfigResponse`. The server sets this based on bandit confidence — shorter intervals when learning, longer when stable. Zero = use client default.

Used by lantern-cloud (sets the value) and radiance (reads it to adjust polling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)