### PR TITLE
feat: add PinnedRouteID to ConfigRequest for sticky manual server selection

### DIFF
--- a/types.go
+++ b/types.go
@@ -111,4 +111,22 @@ type ConfigRequest struct {
 	Protocols         []string        `json:"protocols,omitempty"`
 	MetricsOptedIn    bool            `json:"metrics_opted_in,omitempty"`
 	Version           string          `json:"version,omitempty"`
+
+	// PinnedRouteID is the server-side route ID the client is currently
+	// connected to as a result of an explicit manual server selection
+	// (Pro-only feature in the UI). When set alongside PreferredLocation,
+	// the server tries to keep this specific route in the assignment
+	// response so the client doesn't have to redial when the bandit (or
+	// hash-ring path) would otherwise pick a different route in the same
+	// or another location.
+	//
+	// The pin is advisory: if the route has been deprecated, destroyed,
+	// or now points at a track the client can't consume, the server
+	// silently omits it from the response. The client should detect the
+	// pin's absence and clear it from local state so the UI no longer
+	// shows the route as "currently selected".
+	//
+	// No server-side per-device state is kept — the client carries this
+	// value across config fetches.
+	PinnedRouteID string `json:"pinned_route_id,omitempty"`
 }

--- a/types_test.go
+++ b/types_test.go
@@ -102,6 +102,36 @@ func TestConfigResponseSerialization(t *testing.T) {
 	}
 }
 
+func TestPinnedRouteIDRoundTrip(t *testing.T) {
+	const pin = "9b39797c-19bd-4a5d-9cf9-8ba06d41dd2c"
+
+	original := ConfigRequest{
+		DeviceID:      "device123",
+		PinnedRouteID: pin,
+	}
+
+	data, err := json.Marshal(original)
+	assert.NoError(t, err)
+
+	// Non-empty value must appear in JSON so the server can read it.
+	assert.Contains(t, string(data), `"pinned_route_id":"`+pin+`"`)
+
+	var deserialized ConfigRequest
+	err = json.Unmarshal(data, &deserialized)
+	assert.NoError(t, err)
+	assert.Equal(t, pin, deserialized.PinnedRouteID)
+
+	// Empty value (clients that don't pin, or have just cleared their pin)
+	// must be omitted from the JSON so requests stay small and the server
+	// can cleanly distinguish "no pin set" from "pin explicitly set to
+	// empty string" (we treat both as no-pin, but the wire shape matters
+	// for log noise / SigNoz attribute presence).
+	zeroReq := ConfigRequest{DeviceID: "device123"}
+	data, err = json.Marshal(zeroReq)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(data), "pinned_route_id")
+}
+
 func TestPollIntervalSecondsRoundTrip(t *testing.T) {
 	original := ConfigResponse{
 		PollIntervalSeconds: 30,


### PR DESCRIPTION
## Summary

The bandit re-picks routes every config fetch (60s..15min cadence per the adaptive poll interval). When a Pro user manually selects a server in the UI, they get a stable connection only until the next `/v1/config-new` round trip — at which point the bandit may select different routes and force a redial. Worst case: every 60s the manually-selected server flickers out.

Add an optional `pinned_route_id` field to `ConfigRequest` so the client can tell the server *"I'm currently connected to this specific route, keep it in the assignment list if you can."* Server-side handling lives in lantern-cloud (separate PR); this is the wire-format change.

## Semantics

- **Advisory.** Server validates each request (route exists, status=running for VPS / not deprecated + expiration in future for legacy phost / callback_verified for peer, track still targets this client) and silently omits the pin from the response if it fails any check.
- **Client-cleared on absence.** The client detects the pin's absence in the assignment list and clears its local pin so the UI stops marking the route as "currently selected."
- **No per-device state on the server.** The client carries the pin across config fetches. Auto-cleans when the underlying route gets autoreplaced or deprecated.
- **Cross-tier allowed.** A Pro user can pin a Free route (they can already be assigned Free routes via the normal bandit). A Free user can pin a route they could already be assigned via the normal path; tier eligibility is enforced via the existing `TargetsClient` check in lantern-cloud, not in this schema.

## Test plan

- [x] Added `TestPinnedRouteIDRoundTrip` exercising both the populated and omitempty paths.
- [x] `go test ./...` — new test passes; the pre-existing `TestConfigRequestDefaultValues` nil-deref panic on line 51 is unrelated (it reads `req.PreferredLocation.Country` on a zero-value request, which has been broken on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)