### PR TITLE
Remove PinnedRouteID from ConfigRequest

### DIFF
--- a/types.go
+++ b/types.go
@@ -111,22 +111,4 @@ type ConfigRequest struct {
 	Protocols         []string        `json:"protocols,omitempty"`
 	MetricsOptedIn    bool            `json:"metrics_opted_in,omitempty"`
 	Version           string          `json:"version,omitempty"`
-
-	// PinnedRouteID is the server-side route ID the client is currently
-	// connected to as a result of an explicit manual server selection
-	// (Pro-only feature in the UI). When set alongside PreferredLocation,
-	// the server tries to keep this specific route in the assignment
-	// response so the client doesn't have to redial when the bandit (or
-	// hash-ring path) would otherwise pick a different route in the same
-	// or another location.
-	//
-	// The pin is advisory: if the route has been deprecated, destroyed,
-	// or now points at a track the client can't consume, the server
-	// silently omits it from the response. The client should detect the
-	// pin's absence and clear it from local state so the UI no longer
-	// shows the route as "currently selected".
-	//
-	// No server-side per-device state is kept — the client carries this
-	// value across config fetches.
-	PinnedRouteID string `json:"pinned_route_id,omitempty"`
 }

--- a/types_test.go
+++ b/types_test.go
@@ -102,36 +102,6 @@ func TestConfigResponseSerialization(t *testing.T) {
 	}
 }
 
-func TestPinnedRouteIDRoundTrip(t *testing.T) {
-	const pin = "9b39797c-19bd-4a5d-9cf9-8ba06d41dd2c"
-
-	original := ConfigRequest{
-		DeviceID:      "device123",
-		PinnedRouteID: pin,
-	}
-
-	data, err := json.Marshal(original)
-	assert.NoError(t, err)
-
-	// Non-empty value must appear in JSON so the server can read it.
-	assert.Contains(t, string(data), `"pinned_route_id":"`+pin+`"`)
-
-	var deserialized ConfigRequest
-	err = json.Unmarshal(data, &deserialized)
-	assert.NoError(t, err)
-	assert.Equal(t, pin, deserialized.PinnedRouteID)
-
-	// Empty value (clients that don't pin, or have just cleared their pin)
-	// must be omitted from the JSON so requests stay small and the server
-	// can cleanly distinguish "no pin set" from "pin explicitly set to
-	// empty string" (we treat both as no-pin, but the wire shape matters
-	// for log noise / SigNoz attribute presence).
-	zeroReq := ConfigRequest{DeviceID: "device123"}
-	data, err = json.Marshal(zeroReq)
-	assert.NoError(t, err)
-	assert.NotContains(t, string(data), "pinned_route_id")
-}
-
 func TestPollIntervalSecondsRoundTrip(t *testing.T) {
 	original := ConfigResponse{
 		PollIntervalSeconds: 30,


### PR DESCRIPTION
Removes the `PinnedRouteID` field added in #24.

That field was part of a server-side sticky-manual-server-selection design that we abandoned during review in favor of [a smaller client-side approach in radiance](https://github.com/getlantern/radiance/pull/480) — preserving the manually-selected outbound in sing-box's selector across config refreshes, no wire-format change needed.

The field never shipped: no server-side handler exists (the [lantern-cloud PR](https://github.com/getlantern/lantern-cloud/pull/2739) was closed unmerged) and no client populates it. Removing it now keeps `ConfigRequest` minimal so future readers don't spend time understanding a feature that was never live.

## Wire-format safety

The field was advisory-by-design (servers that ignored it had no effect). Since no server reads it today, removing it from the request shape has no behavioral effect on any existing client or server.

## Test plan

- [x] `go test ./...` clean
- [x] `TestConfigRequestSerialization` still passes (the field isn't touched in that test)