### PR TITLE
feat: add NonSelectableOutbounds to ConfigResponse

### DIFF
--- a/types.go
+++ b/types.go
@@ -81,6 +81,14 @@ type ConfigResponse struct {
 	SmartRouting      SmartRoutingRules `json:"smart_routing,omitempty"`
 	AdBlock           AdBlockRules      `json:"ad_block,omitempty"`
 
+	// NonSelectableOutbounds lists the tags of outbounds in Options that are
+	// infrastructure (e.g. a proxyless download_detour for rule-set fetches) and
+	// must NOT be offered as user-selectable proxies: the client merges them into
+	// its box config so references resolve, but excludes them from the auto/manual
+	// selector groups. This lets the server introduce new optional/infra outbounds
+	// without a client release — the client honors whatever tags appear here.
+	NonSelectableOutbounds []string `json:"non_selectable_outbounds,omitempty"`
+
 	// PollIntervalSeconds tells the client how long to wait before fetching
 	// a new config. The server adjusts this based on bandit confidence —
 	// shorter intervals when learning (new ASN, high entropy), longer when

--- a/types.go
+++ b/types.go
@@ -82,11 +82,14 @@ type ConfigResponse struct {
 	AdBlock           AdBlockRules      `json:"ad_block,omitempty"`
 
 	// NonSelectableOutbounds lists the tags of outbounds in Options that are
-	// infrastructure (e.g. a proxyless download_detour for rule-set fetches) and
-	// must NOT be offered as user-selectable proxies: the client merges them into
-	// its box config so references resolve, but excludes them from the auto/manual
-	// selector groups. This lets the server introduce new optional/infra outbounds
-	// without a client release — the client honors whatever tags appear here.
+	// infrastructure (e.g. a proxyless download_detour for rule-set fetches). The
+	// client merges them into its box config so references (download_detour, route
+	// rules) resolve, but keeps them out of BOTH proxy-selection groups:
+	//   - they are NOT added to the auto (URLTest) group, so auto-selection never
+	//     routes user traffic through them, and
+	//   - they are NOT offered in the manual selector, so the user can't pick them.
+	// This lets the server introduce new optional/infra outbounds without a client
+	// release — the client honors whatever tags appear here.
 	NonSelectableOutbounds []string `json:"non_selectable_outbounds,omitempty"`
 
 	// PollIntervalSeconds tells the client how long to wait before fetching

--- a/types_test.go
+++ b/types_test.go
@@ -141,10 +141,12 @@ func TestNonSelectableOutboundsRoundTrip(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"proxyless"}, deserialized.NonSelectableOutbounds)
 
-	// Empty/nil should be omitted from JSON.
-	data, err = json.Marshal(ConfigResponse{})
-	assert.NoError(t, err)
-	assert.NotContains(t, string(data), "non_selectable_outbounds")
+	// Both nil and a non-nil empty slice should be omitted from JSON.
+	for _, empty := range []ConfigResponse{{}, {NonSelectableOutbounds: []string{}}} {
+		data, err = json.Marshal(empty)
+		assert.NoError(t, err)
+		assert.NotContains(t, string(data), "non_selectable_outbounds")
+	}
 }
 
 func TestConfigResponseDefaultValues(t *testing.T) {

--- a/types_test.go
+++ b/types_test.go
@@ -125,6 +125,26 @@ func TestPollIntervalSecondsRoundTrip(t *testing.T) {
 	assert.NotContains(t, string(data), "poll_interval_seconds")
 }
 
+func TestNonSelectableOutboundsRoundTrip(t *testing.T) {
+	original := ConfigResponse{
+		NonSelectableOutbounds: []string{"proxyless"},
+	}
+
+	data, err := json.Marshal(original)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), `"non_selectable_outbounds":["proxyless"]`)
+
+	var deserialized ConfigResponse
+	err = json.Unmarshal(data, &deserialized)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"proxyless"}, deserialized.NonSelectableOutbounds)
+
+	// Empty/nil should be omitted from JSON.
+	data, err = json.Marshal(ConfigResponse{})
+	assert.NoError(t, err)
+	assert.NotContains(t, string(data), "non_selectable_outbounds")
+}
+
 func TestConfigResponseDefaultValues(t *testing.T) {
 	resp := ConfigResponse{}
 	if len(resp.Servers) != 0 {

--- a/types_test.go
+++ b/types_test.go
@@ -132,7 +132,9 @@ func TestNonSelectableOutboundsRoundTrip(t *testing.T) {
 
 	data, err := json.Marshal(original)
 	assert.NoError(t, err)
-	assert.Contains(t, string(data), `"non_selectable_outbounds":["proxyless"]`)
+	// Verify the JSON tag name is present (not an exact substring, which would be
+	// brittle to encoder formatting); the round-trip below verifies the value.
+	assert.Contains(t, string(data), `"non_selectable_outbounds"`)
 
 	var deserialized ConfigResponse
 	err = json.Unmarshal(data, &deserialized)


### PR DESCRIPTION
Adds `NonSelectableOutbounds []string` to `ConfigResponse`: the tags of outbounds that are infrastructure (e.g. a proxyless `download_detour` for rule-set fetches) and must **not** be offered as user-selectable proxies.

The client merges these outbounds into its box config so `download_detour` / rule references resolve, but excludes them from the auto/manual selector groups. This generalizes the mechanism so the server can introduce new optional/infra outbounds **without a client release** — the client honors whatever tags appear here.

Consumers (depend on this):
- getlantern/lantern-cloud#2936 — sets the field when it emits the proxyless outbound.
- getlantern/radiance#549 — excludes these tags from the selectable set.

Context: getlantern/engineering#3657.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGpKfgkbfdJwwsTaouMDoR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new optional configuration field, `non_selectable_outbounds`, allowing servers to supply outbound tags that are merged into the client’s sing-box configuration for reference resolution.
  * These tagged outbounds are excluded from both automatic proxy selection and manual proxy selection.
* **Tests**
  * Added a unit test to verify `non_selectable_outbounds` JSON round-trips correctly and is omitted when unset or empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->