### PR TITLE
feat: add ConfigRequest.Capabilities for client capability negotiation

### DIFF
--- a/types.go
+++ b/types.go
@@ -21,6 +21,19 @@ const (
 	UNBOUNDED = "unbounded"
 )
 
+// Client capabilities, advertised in ConfigRequest.Capabilities, let the server
+// enable optional behavior per-client — capability negotiation instead of
+// version sniffing.
+const (
+	// CapabilityNonSelectableOutbounds: the client honors
+	// ConfigResponse.NonSelectableOutbounds (merges those outbounds into its box
+	// config but keeps them out of the proxy-selection groups). The server gates
+	// infrastructure outbounds like the proxyless download_detour on this, so an
+	// older client can't surface one as a selectable proxy and route traffic
+	// through it.
+	CapabilityNonSelectableOutbounds = "non_selectable_outbounds"
+)
+
 type ServerLocation struct {
 	Country     string  `json:"country,omitempty"`
 	City        string  `json:"city,omitempty"`
@@ -120,6 +133,9 @@ type ConfigRequest struct {
 	Backend           string          `json:"backend,omitempty"`
 	Locale            string          `json:"locale,omitempty"`
 	Protocols         []string        `json:"protocols,omitempty"`
-	MetricsOptedIn    bool            `json:"metrics_opted_in,omitempty"`
-	Version           string          `json:"version,omitempty"`
+	// Capabilities advertises optional client behaviors the server can gate on
+	// (see the Capability* consts), e.g. honoring NonSelectableOutbounds.
+	Capabilities   []string `json:"capabilities,omitempty"`
+	MetricsOptedIn bool     `json:"metrics_opted_in,omitempty"`
+	Version        string   `json:"version,omitempty"`
 }

--- a/types_test.go
+++ b/types_test.go
@@ -149,6 +149,28 @@ func TestNonSelectableOutboundsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestCapabilitiesRoundTrip(t *testing.T) {
+	original := ConfigRequest{
+		Capabilities: []string{CapabilityNonSelectableOutbounds},
+	}
+
+	data, err := json.Marshal(original)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), `"capabilities"`)
+
+	var deserialized ConfigRequest
+	err = json.Unmarshal(data, &deserialized)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{CapabilityNonSelectableOutbounds}, deserialized.Capabilities)
+
+	// Both nil and a non-nil empty slice should be omitted from JSON.
+	for _, empty := range []ConfigRequest{{}, {Capabilities: []string{}}} {
+		data, err = json.Marshal(empty)
+		assert.NoError(t, err)
+		assert.NotContains(t, string(data), "capabilities")
+	}
+}
+
 func TestConfigResponseDefaultValues(t *testing.T) {
 	resp := ConfigResponse{}
 	if len(resp.Servers) != 0 {

--- a/types_test.go
+++ b/types_test.go
@@ -167,7 +167,7 @@ func TestCapabilitiesRoundTrip(t *testing.T) {
 	for _, empty := range []ConfigRequest{{}, {Capabilities: []string{}}} {
 		data, err = json.Marshal(empty)
 		assert.NoError(t, err)
-		assert.NotContains(t, string(data), "capabilities")
+		assert.NotContains(t, string(data), `"capabilities"`)
 	}
 }
 


### PR DESCRIPTION
## What

Add a **`Capabilities []string`** field to `ConfigRequest` and the first capability constant:

```go
CapabilityNonSelectableOutbounds = "non_selectable_outbounds"
```

The client advertises capabilities it supports; the server enables optional behavior only for clients that report the matching capability — **capability negotiation instead of version sniffing.**

## Why

lantern-cloud gates its new **proxyless rule-set detour** (an infrastructure outbound sent via `ConfigResponse.NonSelectableOutbounds`) on whether the client will treat that outbound as non-selectable. A client that *doesn't* (pre–getlantern/radiance#549) would let its URLTest auto-select the low-latency direct+frag dialer and route traffic through it — exposing the real IP.

The current gate is a hardcoded client-version floor (`9.1.14-beta`). A capability is strictly better:

- **Correct signal.** "Client honors `NonSelectableOutbounds`" is exactly the property that matters — not a version number that has to be kept in sync with whichever release happened to carry #549 (and breaks across forks/prereleases).
- **Generalizes.** #549 honors *any* tag in `NonSelectableOutbounds`. Gating on this one capability covers **every future infra outbound** with no new token and no client release — the whole point of `NonSelectableOutbounds`. Gating on `"proxyless"` specifically would need a new token per outbound.
- **Symmetric.** The client says *"I understand `non_selectable_outbounds`"* ↔ the server sends `non_selectable_outbounds`.

Note: the client already advertises the outline outbound *type* (`"outline"`) via its auto-derived supported-protocols list, but that predates #549 — so it can't be used as the gate (old clients report it too). This new, explicitly-added capability is the safe signal.

## Consumers

- **radiance** — advertises `CapabilityNonSelectableOutbounds` in `config/fetcher.go` (added in the same code that honors `NonSelectableOutbounds`, so advertising it ⟺ handling it safely).
- **lantern-cloud#2936** — gates the proxyless detour on `slices.Contains(req.Capabilities, common.CapabilityNonSelectableOutbounds)`, replacing the version floor.

## Testing

`go test ./...` — `TestCapabilitiesRoundTrip` (key present, value round-trips, nil + empty-slice both omitted). Build + gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGpKfgkbfdJwwsTaouMDoR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added client capability support for configuration negotiation.
  * Introduced a capability flag for handling non-selectable outbounds, helping clients and servers agree on outbound behavior.
  * Added a new request field to send capability information during configuration requests.

* **Tests**
  * Added coverage to verify capability data is preserved through JSON serialization and omitted when empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->