### PR TITLE
Add RouteSelectionReportIntervalSeconds and BanditReportTokens to ConfigResponse

### DIFF
--- a/types.go
+++ b/types.go
@@ -94,6 +94,18 @@ type ConfigResponse struct {
 	BanditURLOverrides  map[string]string `json:"bandit_url_overrides,omitempty"`
 	BanditThroughputURL string            `json:"bandit_throughput_url,omitempty"`
 
+	// RouteSelectionReportIntervalSeconds tells the client how often to POST
+	// its per-route selection history (data-plane stall/reset counters) back
+	// to the server's /v1/bandit/report endpoint. Omitted or zero means the
+	// client does not report — the interval doubles as the enable switch.
+	RouteSelectionReportIntervalSeconds int `json:"route_selection_report_interval_seconds,omitempty"`
+
+	// BanditReportTokens maps outbound tags to HMAC-signed opaque report
+	// tokens, parallel to BanditURLOverrides. The client echoes each tag's
+	// token back in its selection-history report so the server can attribute
+	// the counters to a route without trusting any client-asserted identity.
+	BanditReportTokens map[string]string `json:"bandit_report_tokens,omitempty"`
+
 	Unbounded *UnboundedConfig `json:"unbounded,omitempty"`
 }
 


### PR DESCRIPTION
Server side of getlantern/engineering#3673 (parent: getlantern/engineering#3671).

Adds two fields to `ConfigResponse`, emitted by lantern-cloud's `/v1/config-new` and consumed by the client's data-plane selection reporter:

- `route_selection_report_interval_seconds` — cadence for the client's per-route stall/reset report. **Doubles as the enable switch**: omitted/zero means the client does not report (old servers never send it, so new clients stay silent against them).
- `bandit_report_tokens` — outbound tag → HMAC-signed opaque report token, parallel to `bandit_url_overrides`. The client echoes the token per tag in its report; the server derives route/arm/ASN attribution entirely from the token.

lantern-cloud currently pins this branch's commit as a pseudo-version (`v1.2.1-0.20260707113942-211dd66dbbd5`); once this merges, the lantern-cloud dep gets bumped to a tagged/main version before its prod merge.

Validated end-to-end on lantern-cloud staging 2026-07-07.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional configuration fields for controlling route-selection reporting.
  * Clients can now receive a configurable reporting interval; setting it to zero (or omitting it) disables route-history reporting.
  * Added support for opaque, server-attributable reporting tokens to link client route selections to server-side attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->