### PR TITLE
Add otel.logs feature flag constant

### DIFF
--- a/types.go
+++ b/types.go
@@ -14,6 +14,9 @@ const (
 	// Whether or not client-side metrics should be enabled.
 	METRICS = "otel.metrics"
 
+	// Whether or not client-side logs should be enabled.
+	LOGS = "otel.logs"
+
 	// Whether or not users should have the option to launch private servers on GCP.
 	GCP = "private.gcp"
 


### PR DESCRIPTION
Spark's new diagnostics uploads an OTLP logs signal that the client gates on `features["otel.logs"]` — this adds the `LOGS` constant as a companion to `TRACES`/`METRICS`.
Consumed by lantern-cloud's config emission and the Spark client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for enabling and configuring client-side logs through the existing feature-flag mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->