### PR TITLE
feat: let a client declare the transport modules it already holds

### DIFF
--- a/types.go
+++ b/types.go
@@ -35,6 +35,19 @@ const (
 	// older client can't surface one as a selectable proxy and route traffic
 	// through it.
 	CapabilityNonSelectableOutbounds = "non_selectable_outbounds"
+
+	// CapabilityTransportModules: the client can install and run a signed
+	// transport-module bundle delivered in its config, and verifies it against a
+	// compiled-in key.
+	//
+	// Needed because ConfigRequest.Modules cannot carry this by itself: it is
+	// omitted when empty, so a client that supports modules but holds none looks
+	// on the wire exactly like a client that cannot use them at all. Without the
+	// capability the server would have to guess, and guessing wrong means either
+	// never bootstrapping a client's first module or sending every client a
+	// module-bearing outbound it will silently skip — with the module's bytes,
+	// which are the expensive part, attached.
+	CapabilityTransportModules = "transport_modules"
 )
 
 type ServerLocation struct {
@@ -153,4 +166,36 @@ type ConfigRequest struct {
 	Capabilities   []string `json:"capabilities,omitempty"`
 	MetricsOptedIn bool     `json:"metrics_opted_in,omitempty"`
 	Version        string   `json:"version,omitempty"`
+
+	// Modules names the signed transport-module bundles the client already
+	// holds, as engine name -> bundle version, so the server can omit bytes it
+	// would otherwise re-send.
+	//
+	// Distinct from Capabilities, which is a set of boolean tokens: this is an
+	// inventory, and its values are what the server compares against. The two
+	// are complementary — CapabilityTransportModules says the client can load a
+	// delivered module at all, and this says which ones it already has. A client
+	// that supports modules but holds none sends the capability and no Modules,
+	// which is exactly the case the server must be able to tell apart from a
+	// client that cannot use them.
+	//
+	// A transport module can be delivered inline in the config itself, which
+	// means it rides every fetch that offers it. The response ETag does not
+	// help: the body is regenerated per request (the bandit re-picks routes),
+	// so it never repeats and never yields a 304. Without this field an inline
+	// module is re-sent on every poll, indefinitely.
+	//
+	// The version rather than a content hash: the client's bundle store already
+	// persists exactly this, and the artifact's own Ed25519 signature is what
+	// authenticates its bytes, so a hash would be a second identity for one
+	// thing.
+	//
+	// This is a hint and never authorization. A client claiming an engine it
+	// cannot actually load simply skips that outbound, so a wrong or dishonest
+	// declaration only degrades that client. Nothing here may gate access, and
+	// omitted bytes must be the only difference it makes.
+	//
+	// Omitted when empty, so a client holding nothing — or one built without
+	// module support — sends exactly what it always sent.
+	Modules map[string]uint32 `json:"modules,omitempty"`
 }

--- a/types_test.go
+++ b/types_test.go
@@ -80,6 +80,42 @@ func TestConfigRequestModulesOmittedWhenEmpty(t *testing.T) {
 	}
 	assert.Equal(t, map[string]uint32{"bip324": 3, "obfs-xor": 1}, back.Modules)
 }
+
+// The capability and the inventory answer different questions, and the server
+// needs both: "can this client run a delivered module at all" is not the same as
+// "which ones does it already have". A client that supports modules but holds
+// none is the case that would otherwise be indistinguishable from one that
+// cannot use them, since Modules is omitted when empty.
+func TestTransportModulesCapabilityIsSeparateFromTheInventory(t *testing.T) {
+	supportsButHoldsNone := ConfigRequest{
+		DeviceID:     "d",
+		Capabilities: []string{CapabilityTransportModules},
+	}
+	data, err := json.Marshal(supportsButHoldsNone)
+	if err != nil {
+		t.Fatalf("Failed to serialize ConfigRequest: %v", err)
+	}
+	var out map[string]json.RawMessage
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("Failed to deserialize ConfigRequest: %v", err)
+	}
+	assert.Contains(t, out, "capabilities", "the capability is what says the client can run a module")
+	assert.NotContains(t, out, "modules", "holding none must still omit the inventory")
+
+	// And a client that cannot use modules sends neither, so the server can tell
+	// the two apart — which is the whole point of the capability.
+	data, err = json.Marshal(ConfigRequest{DeviceID: "d"})
+	if err != nil {
+		t.Fatalf("Failed to serialize ConfigRequest: %v", err)
+	}
+	out = nil
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("Failed to deserialize ConfigRequest: %v", err)
+	}
+	assert.NotContains(t, out, "capabilities")
+	assert.NotContains(t, out, "modules")
+}
+
 func TestConfigResponseSerialization(t *testing.T) {
 	original := ConfigResponse{
 		Servers: []ServerLocation{

--- a/types_test.go
+++ b/types_test.go
@@ -59,21 +59,46 @@ func TestConfigRequestDefaultValues(t *testing.T) {
 // field existed. The declaration is an optimization; it must not become a way to
 // tell an older client from a newer one, nor a reason to treat them differently.
 func TestConfigRequestModulesOmittedWhenEmpty(t *testing.T) {
-	data, err := json.Marshal(ConfigRequest{DeviceID: "d"})
-	if err != nil {
-		t.Fatalf("Failed to serialize ConfigRequest: %v", err)
+	// Decode and look for the key rather than substring-searching the JSON: a search for "modules"
+	// would also match the word appearing inside some other field's value, so it could pass for the
+	// wrong reason. The property under test is "no such key".
+	keys := func(t *testing.T, req ConfigRequest) map[string]json.RawMessage {
+		t.Helper()
+		data, err := json.Marshal(req)
+		if err != nil {
+			t.Fatalf("Failed to serialize ConfigRequest: %v", err)
+		}
+		var out map[string]json.RawMessage
+		if err := json.Unmarshal(data, &out); err != nil {
+			t.Fatalf("Failed to deserialize ConfigRequest: %v", err)
+		}
+		return out
 	}
-	assert.NotContains(t, string(data), "modules", "an empty Modules map must be omitted entirely")
 
-	data, err = json.Marshal(ConfigRequest{
+	// Both empties, because they are different values that must behave the same. `omitempty` drops a
+	// map of length zero, so nil and an initialized-but-empty map are equivalent *today* — asserting
+	// only the nil case would let a later change to the tag or the field's type break the other
+	// silently, which is exactly the kind of gap this test exists to close.
+	for name, modules := range map[string]map[string]uint32{
+		"nil":   nil,
+		"empty": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.NotContains(t, keys(t, ConfigRequest{DeviceID: "d", Modules: modules}), "modules",
+				"a client holding no modules must send no `modules` key at all")
+		})
+	}
+
+	held := ConfigRequest{
 		DeviceID: "d",
 		Modules:  map[string]uint32{"bip324": 3, "obfs-xor": 1},
-	})
+	}
+	assert.JSONEq(t, `{"bip324":3,"obfs-xor":1}`, string(keys(t, held)["modules"]))
+
+	data, err := json.Marshal(held)
 	if err != nil {
 		t.Fatalf("Failed to serialize ConfigRequest: %v", err)
 	}
-	assert.Contains(t, string(data), `"modules":{"bip324":3,"obfs-xor":1}`)
-
 	var back ConfigRequest
 	if err := json.Unmarshal(data, &back); err != nil {
 		t.Fatalf("Failed to deserialize ConfigRequest: %v", err)

--- a/types_test.go
+++ b/types_test.go
@@ -48,9 +48,37 @@ func TestConfigRequestDefaultValues(t *testing.T) {
 	if req.DeviceID != "" {
 		t.Errorf("Expected default DeviceID to be empty, got: %s", req.DeviceID)
 	}
-	if req.PreferredLocation.Country != "" {
-		t.Errorf("Expected default PreferredLocation.Country to be empty, got: %s", req.PreferredLocation.Country)
+	// PreferredLocation is a pointer, so its zero value is nil — dereferencing it
+	// to read .Country panics rather than testing anything.
+	if req.PreferredLocation != nil {
+		t.Errorf("Expected default PreferredLocation to be nil, got: %+v", req.PreferredLocation)
 	}
+}
+
+// A client holding no modules must serialize to exactly what it did before the
+// field existed. The declaration is an optimization; it must not become a way to
+// tell an older client from a newer one, nor a reason to treat them differently.
+func TestConfigRequestModulesOmittedWhenEmpty(t *testing.T) {
+	data, err := json.Marshal(ConfigRequest{DeviceID: "d"})
+	if err != nil {
+		t.Fatalf("Failed to serialize ConfigRequest: %v", err)
+	}
+	assert.NotContains(t, string(data), "modules", "an empty Modules map must be omitted entirely")
+
+	data, err = json.Marshal(ConfigRequest{
+		DeviceID: "d",
+		Modules:  map[string]uint32{"bip324": 3, "obfs-xor": 1},
+	})
+	if err != nil {
+		t.Fatalf("Failed to serialize ConfigRequest: %v", err)
+	}
+	assert.Contains(t, string(data), `"modules":{"bip324":3,"obfs-xor":1}`)
+
+	var back ConfigRequest
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("Failed to deserialize ConfigRequest: %v", err)
+	}
+	assert.Equal(t, map[string]uint32{"bip324": 3, "obfs-xor": 1}, back.Modules)
 }
 func TestConfigResponseSerialization(t *testing.T) {
 	original := ConfigResponse{


### PR DESCRIPTION
Adds `ConfigRequest.Modules` — engine name → bundle version — so the config
server can omit transport-module bytes a client already has.

## Why

Spark can be sent a signed WASM transport module **inline in its config**
(getlantern/spark#114), so the artifact rides every fetch that offers it.
`bip324` is ~10 KB gzipped against a ~2.7 KB baseline config, so this is not a
rounding error.

The response `ETag` does not help, and I measured this against prod rather than
assuming it:

- An `ETag` **is** returned, and it is a body hash.
- But the body is **regenerated per request** — two identical requests return
  different bodies, because the bandit re-picks routes each time (the samizdat
  route UUID changes between calls).
- So the `ETag` never repeats and never yields a `304`.

Without a way for the client to say what it already holds, an inline module is
re-sent on **every poll, indefinitely**.

## Design notes

**Version, not a content hash.** The client's bundle store already persists
exactly this, and the artifact's own Ed25519 signature is what authenticates its
bytes — so a hash would be a second identity for one thing.

**A hint, never authorization.** A client claiming an engine it cannot actually
load simply skips that outbound, so a wrong or dishonest declaration only
degrades that client. Nothing here may gate access, and omitted bytes must be
the only difference it makes. Both properties are documented at the field so the
server-side implementation inherits them.

**Omitted when empty**, so a client holding nothing — or one built without module
support — serializes exactly what it always did. Covered by a test, since that
back-compat property is the one worth pinning.

## Also here

A drive-by fix: `TestConfigRequestDefaultValues` built a zero-valued
`ConfigRequest` and then read `req.PreferredLocation.Country`.
`PreferredLocation` is a `*ServerLocation`, so its zero value is nil and the read
panics — this package's tests have been failing rather than asserting anything.
It now asserts the pointer is nil, which is what the test evidently meant.

Separate commit, so it can be dropped if you'd rather fix it elsewhere.

## Client side

getlantern/spark#206 (merged) implements the client half: it sources the map from
its bundle store, declaring an engine only if the artifact actually loads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration requests can report locally available signed module bundle versions, helping avoid unnecessary module data transfers.
  * Module availability details are omitted when no modules are present.
  * Module availability information is preserved when configuration requests are serialized and restored.

* **Bug Fixes**
  * Corrected handling of default configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->